### PR TITLE
Release 1.1.2: reliable streaming updates, clearData(), and Syncfusion 34.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
 
 * Added RTL layout support by forcing LTR directionality on chart and slider rows in both SimpleOscilloscope and AlternativeSimpleOscilloscope.
 
+## 1.1.2
+
+* Fixed stale trailing points remaining on the `AlternativeSimpleOscilloscope` chart when a series is replaced with a shorter list. Data updates are now pushed through `ChartSeriesController.updateDataSource`, which also avoids a full `SfCartesianChart` rebuild on data-only changes.
+* Added `AlternativeSimpleOscilloscopeState.clearData()` to immediately clear all rendered data, and exposed the state class publicly so it can be reached through a `GlobalKey`.
+
 ## 1.1.1
 
 * Fixed threshold dialog text field displaying negative values incorrectly in RTL locales.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 * Fixed stale trailing points remaining on the `AlternativeSimpleOscilloscope` chart when a series is replaced with a shorter list. Data updates are now pushed through `ChartSeriesController.updateDataSource`, which also avoids a full `SfCartesianChart` rebuild on data-only changes.
 * Added `AlternativeSimpleOscilloscopeState.clearData()` to immediately clear all rendered data, and exposed the state class publicly so it can be reached through a `GlobalKey`.
+* Upgraded the Syncfusion dependencies (`syncfusion_flutter_charts`, `syncfusion_flutter_core`, `syncfusion_flutter_sliders`) from `^33.2.3` to `^34.1.33` in both the package and the example app.
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
 * Fixed stale trailing points remaining on the `AlternativeSimpleOscilloscope` chart when a series is replaced with a shorter list. Data updates are now pushed through `ChartSeriesController.updateDataSource`, which also avoids a full `SfCartesianChart` rebuild on data-only changes.
 * Added `AlternativeSimpleOscilloscopeState.clearData()` to immediately clear all rendered data, and exposed the state class publicly so it can be reached through a `GlobalKey`.
 * Upgraded the Syncfusion dependencies (`syncfusion_flutter_charts`, `syncfusion_flutter_core`, `syncfusion_flutter_sliders`) from `^33.2.3` to `^34.1.33` in both the package and the example app.
+* Fixed stale data persisting on `AlternativeSimpleOscilloscope` after the number of series changes. Surviving series now get a generation-keyed rebuild so their `ChartSeriesController` is recaptured (otherwise `updateDataSource` was silently skipped and stale points remained).
+* Fixed a threshold drag being reverted on every data-tick rebuild in both `SimpleOscilloscope` and `AlternativeSimpleOscilloscope`. Threshold change detection now compares the previous vs new widget instead of state vs widget.
+* Wrapped the `AlternativeSimpleOscilloscope` chart in a `RepaintBoundary` for streaming paint isolation.
+* Added a streaming (timer-driven) example that exercises the real-time update path of both oscilloscopes.
+* Cleanup: removed a dead `identical()` guard, switched to plain `GlobalKey` types, re-measure slider padding when axis config changes, reuse an index buffer for data updates, and use `Object.hash` for `OscilloscopePoint.hashCode`.
+* BREAKING (minor): made `calculateZoomedMin`/`calculateZoomedMax` private (they were undocumented internal helpers).
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 
 * Added RTL layout support by forcing LTR directionality on chart and slider rows in both SimpleOscilloscope and AlternativeSimpleOscilloscope.
 
+## 1.1.1
+
+* Fixed threshold dialog text field displaying negative values incorrectly in RTL locales.
+
 ## 1.1.2
 
 * Fixed stale trailing points remaining on the `AlternativeSimpleOscilloscope` chart when a series is replaced with a shorter list. Data updates are now pushed through `ChartSeriesController.updateDataSource`, which also avoids a full `SfCartesianChart` rebuild on data-only changes.
@@ -52,7 +56,3 @@
 * Added a streaming (timer-driven) example that exercises the real-time update path of both oscilloscopes.
 * Cleanup: removed a dead `identical()` guard, switched to plain `GlobalKey` types, re-measure slider padding when axis config changes, reuse an index buffer for data updates, and use `Object.hash` for `OscilloscopePoint.hashCode`.
 * BREAKING (minor): made `calculateZoomedMin`/`calculateZoomedMax` private (they were undocumented internal helpers).
-
-## 1.1.1
-
-* Fixed threshold dialog text field displaying negative values incorrectly in RTL locales.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A customizable oscilloscope widget for Flutter, providing features such as dynam
     - [Usage](#usage)
         - [Using `SimpleOscilloscope` Widget](#using-simpleoscilloscope-widget)
         - [Using `AlternativeSimpleOscilloscope` Widget](#using-alternativesimpleoscilloscope-widget)
+            - [Updating Data and Clearing the Chart](#updating-data-and-clearing-the-chart-alternativesimpleoscilloscope)
         - [Configuring `OscilloscopeAxisChartData`](#configuring-oscilloscopeaxischartdata)
     - [Contributing](#contributing)
     - [License](#license)
@@ -37,6 +38,7 @@ A customizable oscilloscope widget for Flutter, providing features such as dynam
 - **Extra Plot Lines:** Add additional horizontal lines for markers or reference points.
 - **Interactive Threshold Manipulation:** Double-tap to reset thresholds or open dialogs for precise adjustments.
 - **Optimized Performance:** Efficient rendering with `RepaintBoundary` and optimized widget structures.
+- **Real-time Streaming & Instant Clearing:** `AlternativeSimpleOscilloscope` streams high-frequency data updates without full chart rebuilds, and can be cleared instantly via `clearData()`.
 - **RTL Layout Support:** Charts, sliders, and dialogs render correctly in both LTR and RTL locales.
 - **Multiple Chart Libraries:** Possibility to use the [syncfusion_flutter_charts](https://pub.dev/packages/syncfusion_flutter_charts) as well as the [fl_chart](https://pub.dev/packages/fl_chart) packages, depending on your preference.
 
@@ -46,7 +48,7 @@ Add `floscilloscope` as a dependency in your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  floscilloscope: ^1.1.1
+  floscilloscope: ^1.1.2
 ```
 
 Then run `flutter pub get` to fetch the package.
@@ -152,6 +154,32 @@ class AlternativeOscilloscopeExample extends StatelessWidget {
   }
 }
 ```
+
+#### Updating Data and Clearing the Chart (AlternativeSimpleOscilloscope)
+
+`AlternativeSimpleOscilloscope` owns its data internally and pushes data-only changes to the chart through `ChartSeriesController.updateDataSource` instead of rebuilding the whole chart. This keeps high-frequency (e.g. timer-driven) updates efficient and correctly removes stale trailing points when a series shrinks or when the number of series changes. Just rebuild the widget with the new `dataPoints`:
+
+```dart
+// On a Timer or in a ValueListenableBuilder callback:
+_chartData.dataPoints[0] = updatedPoints;
+setState(() {});
+```
+
+To clear all rendered data immediately — bypassing the rebuild cycle — reach the (public) state through a `GlobalKey` and call `clearData()`:
+
+```dart
+final _chartKey = GlobalKey<AlternativeSimpleOscilloscopeState>();
+
+AlternativeSimpleOscilloscope(
+  key: _chartKey,
+  oscilloscopeAxisChartData: _chartData,
+);
+
+// Clear instantly, e.g. when starting a new acquisition:
+_chartKey.currentState?.clearData();
+```
+
+A threshold you set by dragging the slider is preserved across data-tick rebuilds; only an actual change to the `threshold` passed into `OscilloscopeAxisChartData` resets the displayed value.
 
 ### Configuring `OscilloscopeAxisChartData`
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:developer';
+import 'dart:math' hide log;
 
 import 'package:floscilloscope/floscilloscope.dart';
 import 'package:flutter/material.dart';
@@ -13,12 +15,12 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'floscilloscope demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(title: 'floscilloscope streaming demo'),
     );
   }
 }
@@ -32,38 +34,67 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
+/// A streaming demo: a 120ms timer overwrites a fixed-size buffer with a sine
+/// wave on two channels, exercising the real-time data-update path of both
+/// oscilloscopes (grow during warmup, same-length update afterwards).
 class _MyHomePageState extends State<MyHomePage> {
-  final OscilloscopeAxisChartData _oscilloscopeAxisChartData =
-      OscilloscopeAxisChartData(
-          threshold: 2.0,
-          thresholdDragStepSize: 2.0,
-          dataPoints: [
-            [
-              const OscilloscopePoint(0, 0),
-              const OscilloscopePoint(2, 3),
-              const OscilloscopePoint(5, 10),
-              const OscilloscopePoint(10, 10),
-              const OscilloscopePoint(12, -45),
-            ],
-            [
-              const OscilloscopePoint(1, 4),
-              const OscilloscopePoint(75, 23),
-              const OscilloscopePoint(19, -20),
-            ],
-            [
-              const OscilloscopePoint(56, 2),
-              const OscilloscopePoint(98, 101),
-              const OscilloscopePoint(109, 150),
-            ]
-          ],
-          numberOfDivisions: 5,
-          horizontalAxisLabel: 'Time',
-          horizontalAxisUnit: 'µs',
-          verticalAxisLabel: 'Voltage',
-          verticalAxisUnit: 'mV',
-          updateButtonLabel: 'Update',
-          onThresholdValueChanged: (value) => log(value.toString()),
-          enableTooltip: true);
+  static const int _maxPoints = 40;
+  static const Duration _tickInterval = Duration(milliseconds: 120);
+
+  late final Timer _timer;
+  late final OscilloscopeAxisChartData _chartData;
+  int _tick = 0;
+
+  final List<List<OscilloscopePoint>> _dataPoints = [
+    <OscilloscopePoint>[const OscilloscopePoint(0, 0)],
+    <OscilloscopePoint>[const OscilloscopePoint(0, 0)],
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _chartData = OscilloscopeAxisChartData(
+      threshold: 2.0,
+      thresholdDragStepSize: 2.0,
+      dataPoints: _dataPoints,
+      numberOfDivisions: 5,
+      horizontalAxisValuePerDivision: 4.0,
+      verticalAxisValuePerDivision: 1.0,
+      horizontalAxisLabel: 'Time',
+      horizontalAxisUnit: 'µs',
+      verticalAxisLabel: 'Voltage',
+      verticalAxisUnit: 'mV',
+      updateButtonLabel: 'Update',
+      onThresholdValueChanged: (value) => log('threshold=$value'),
+      enableTooltip: true,
+    );
+    _timer = Timer.periodic(_tickInterval, (_) {
+      _tick++;
+      _appendData();
+      setState(() {});
+    });
+  }
+
+  void _appendData() {
+    final int index = _tick % _maxPoints;
+    final double phaseStep = _tick * 0.3;
+    for (int s = 0; s < _dataPoints.length; s++) {
+      final double phase = s == 0 ? 0.0 : pi;
+      final double y = 5 * sin(phaseStep + phase);
+      final List<OscilloscopePoint> series = _dataPoints[s];
+      if (series.length < _maxPoints) {
+        series.add(OscilloscopePoint(index.toDouble(), y));
+      } else {
+        series[index] = OscilloscopePoint(index.toDouble(), y);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -77,15 +108,17 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             Flexible(
-                flex: 1,
-                child: SimpleOscilloscope(
-                  oscilloscopeAxisChartData: _oscilloscopeAxisChartData,
-                )),
+              flex: 1,
+              child: SimpleOscilloscope(
+                oscilloscopeAxisChartData: _chartData,
+              ),
+            ),
             Flexible(
               flex: 1,
-                child: AlternativeSimpleOscilloscope(
-              oscilloscopeAxisChartData: _oscilloscopeAxisChartData,
-            ))
+              child: AlternativeSimpleOscilloscope(
+                oscilloscopeAxisChartData: _chartData,
+              ),
+            ),
           ],
         ),
       ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,8 +28,8 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  syncfusion_flutter_core: ^33.2.3
-  syncfusion_flutter_sliders: ^33.2.3
+  syncfusion_flutter_core: ^34.1.33
+  syncfusion_flutter_sliders: ^34.1.33
   fl_chart: ^1.2.0
   flutter:
     sdk: flutter

--- a/lib/src/oscilloscope/alternative_simple_oscilloscope.dart
+++ b/lib/src/oscilloscope/alternative_simple_oscilloscope.dart
@@ -107,15 +107,20 @@ class AlternativeSimpleOscilloscopeState
   double _thresholdValue = 0.0;
   double _sliderBottomPadding = 0.0;
 
-  final GlobalKey<AlternativeSimpleOscilloscopeState> _primaryXAxisRenderKey =
-      GlobalKey<AlternativeSimpleOscilloscopeState>();
-  final GlobalKey<AlternativeSimpleOscilloscopeState> _primaryYAxisRenderKey =
-      GlobalKey<AlternativeSimpleOscilloscopeState>();
+  final GlobalKey _primaryXAxisRenderKey = GlobalKey();
+  final GlobalKey _primaryYAxisRenderKey = GlobalKey();
 
   late double _thresholdProgressbarMaximum;
   late double _thresholdProgressbarMinimum;
   late double _zoomFactor = 1.0;
   late double _zoomPosition = 0.0;
+
+  /// Bumped whenever the number of series changes so each surviving series
+  /// gets a fresh key and its renderer is recreated. This forces
+  /// [LineSeries.onRendererCreated] to fire again so the series controller is
+  /// recaptured; otherwise it would stay null and data updates would be
+  /// silently skipped after a count change.
+  int _seriesGen = 0;
 
   /// Mutable data source lists owned by this state. These are the lists handed
   /// to each [LineSeries] as its `dataSource`; they are updated in place so the
@@ -126,6 +131,12 @@ class AlternativeSimpleOscilloscopeState
   /// [LineSeries.onRendererCreated]. Used to push incremental data updates
   /// without rebuilding the whole chart.
   late List<ChartSeriesController?> _seriesControllers;
+
+  /// Reusable buffer of consecutive indexes handed to
+  /// [ChartSeriesController.updateDataSource]. Syncfusion copies the list
+  /// immediately, so a single buffer can be reused across calls, series, and
+  /// ticks to avoid per-tick allocations.
+  final List<int> _indexBuffer = [];
 
   Timer? _doubleTapTimer;
   int _pointerCount = 0;
@@ -170,16 +181,24 @@ class AlternativeSimpleOscilloscopeState
     _handleDataUpdate(oldWidget.oscilloscopeAxisChartData.dataPoints,
         widget.oscilloscopeAxisChartData.dataPoints);
 
-    if (widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision !=
+    final bool axisConfigChanged =
+        widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision !=
             oldWidget.oscilloscopeAxisChartData.verticalAxisValuePerDivision ||
         widget.oscilloscopeAxisChartData.numberOfDivisions !=
-            oldWidget.oscilloscopeAxisChartData.numberOfDivisions ||
-        _thresholdValue != widget.oscilloscopeAxisChartData.threshold) {
+            oldWidget.oscilloscopeAxisChartData.numberOfDivisions;
+    if (axisConfigChanged ||
+        widget.oscilloscopeAxisChartData.threshold !=
+            oldWidget.oscilloscopeAxisChartData.threshold) {
       setState(() {
         _thresholdValue = widget.oscilloscopeAxisChartData.threshold;
         _thresholdProgressbarValue = _thresholdValue;
         _handleZoom();
       });
+      if (axisConfigChanged) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _calculateBottomPadding();
+        });
+      }
     }
   }
 
@@ -203,6 +222,7 @@ class AlternativeSimpleOscilloscopeState
       List<List<OscilloscopePoint>> newData) {
     if (newData.length != _dataSources.length) {
       setState(() {
+        _seriesGen++;
         _dataSources =
             newData.map((list) => List<OscilloscopePoint>.from(list)).toList();
         _seriesControllers =
@@ -216,10 +236,6 @@ class AlternativeSimpleOscilloscopeState
       final source = _dataSources[i];
       final incoming = newData[i];
 
-      if (identical(source, incoming) && source.length == incoming.length) {
-        continue;
-      }
-
       final oldLen = source.length;
       source
         ..clear()
@@ -232,32 +248,39 @@ class AlternativeSimpleOscilloscopeState
 
       if (newLen == oldLen) {
         if (newLen > 0) {
-          controller.updateDataSource(
-            updatedDataIndexes: List<int>.generate(newLen, (i) => i),
-          );
+          controller.updateDataSource(updatedDataIndexes: _range(0, newLen));
         }
       } else if (newLen < oldLen) {
         if (newLen > 0) {
-          controller.updateDataSource(
-            updatedDataIndexes: List<int>.generate(newLen, (i) => i),
-          );
+          controller.updateDataSource(updatedDataIndexes: _range(0, newLen));
         }
         controller.updateDataSource(
-          removedDataIndexes:
-              List<int>.generate(oldLen - newLen, (i) => newLen + i),
-        );
+            removedDataIndexes: _range(newLen, oldLen - newLen));
       } else {
         if (oldLen > 0) {
-          controller.updateDataSource(
-            updatedDataIndexes: List<int>.generate(oldLen, (i) => i),
-          );
+          controller.updateDataSource(updatedDataIndexes: _range(0, oldLen));
         }
         controller.updateDataSource(
-          addedDataIndexes:
-              List<int>.generate(newLen - oldLen, (i) => oldLen + i),
-        );
+            addedDataIndexes: _range(oldLen, newLen - oldLen));
       }
     }
+  }
+
+  /// Returns consecutive indexes `[start, start + 1, ..., start + count - 1]`
+  /// using a shared, reusable buffer. Syncfusion copies the list inside
+  /// [ChartSeriesController.updateDataSource], so the same buffer can be reused
+  /// across calls, series, and ticks.
+  List<int> _range(int start, int count) {
+    while (_indexBuffer.length < count) {
+      _indexBuffer.add(0);
+    }
+    if (_indexBuffer.length > count) {
+      _indexBuffer.removeRange(count, _indexBuffer.length);
+    }
+    for (int i = 0; i < count; i++) {
+      _indexBuffer[i] = start + i;
+    }
+    return _indexBuffer;
   }
 
   /// Immediately clears every rendered series.
@@ -277,12 +300,28 @@ class AlternativeSimpleOscilloscopeState
       final oldLen = _dataSources[i].length;
       _dataSources[i].clear();
       if (controller != null && oldLen > 0) {
-        controller.updateDataSource(
-          removedDataIndexes: List<int>.generate(oldLen, (i) => i),
-        );
+        controller.updateDataSource(removedDataIndexes: _range(0, oldLen));
       }
     }
   }
+
+  /// The number of series whose [ChartSeriesController] has been captured.
+  ///
+  /// Exposed for testing: after a series-count change every surviving series
+  /// must recapture its controller, otherwise data updates are silently
+  /// skipped and stale points remain on the chart.
+  @visibleForTesting
+  int get controllerCount =>
+      _seriesControllers.whereType<ChartSeriesController>().length;
+
+  /// The threshold value currently held by this state.
+  ///
+  /// Exposed for testing so a user drag can be simulated without driving the
+  /// slider gestures, and so the value can be asserted after a rebuild.
+  @visibleForTesting
+  double get currentThresholdValue => _thresholdValue;
+  @visibleForTesting
+  set currentThresholdValue(double value) => _thresholdValue = value;
 
   void _clampThresholdProgressbarValue() {
     _thresholdProgressbarValue = _thresholdProgressbarValue.clamp(
@@ -311,14 +350,13 @@ class AlternativeSimpleOscilloscopeState
     _clampThresholdProgressbarValue();
   }
 
-  double calculateZoomedMin(double currentMin, double currentMax,
-      double zoomFactor, double zoomPosition) {
+  double _calculateZoomedMin(
+      double currentMin, double currentMax, double zoomPosition) {
     double range = currentMax - currentMin;
-    double zoomedMin = currentMin + range * zoomPosition;
-    return zoomedMin;
+    return currentMin + range * zoomPosition;
   }
 
-  double calculateZoomedMax(double zoomedMin, double currentMin,
+  double _calculateZoomedMax(double zoomedMin, double currentMin,
       double currentMax, double zoomFactor) {
     double range = currentMax - currentMin;
     double zoomedRange = range * zoomFactor;
@@ -339,7 +377,8 @@ class AlternativeSimpleOscilloscopeState
               children: [
                 Flexible(
                     flex: 3,
-                    child: SfCartesianChart(
+                    child: RepaintBoundary(
+                        child: SfCartesianChart(
                       tooltipBehavior: TooltipBehavior(
                         enable: widget.oscilloscopeAxisChartData.enableTooltip,
                         animationDuration: 0,
@@ -439,7 +478,8 @@ class AlternativeSimpleOscilloscopeState
                       series: [
                         ..._dataSources.asMap().entries.map((entry) {
                           return LineSeries<OscilloscopePoint, double>(
-                            key: ValueKey<String>('series_${entry.key}'),
+                            key: ValueKey<String>(
+                                'series_${entry.key}_gen$_seriesGen'),
                             dataLabelSettings:
                                 const DataLabelSettings(isVisible: false),
                             enableTooltip:
@@ -460,6 +500,7 @@ class AlternativeSimpleOscilloscopeState
                         })
                       ],
                     )),
+                  ),
                 const SizedBox(width: 16),
                 ThresholdSlider(
                   min: _thresholdProgressbarMinimum,
@@ -517,10 +558,9 @@ class AlternativeSimpleOscilloscopeState
         widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision *
             widget.oscilloscopeAxisChartData.numberOfDivisions;
 
-    double zoomedMin =
-        calculateZoomedMin(currentMin, currentMax, _zoomFactor, _zoomPosition);
+    double zoomedMin = _calculateZoomedMin(currentMin, currentMax, _zoomPosition);
     double zoomedMax =
-        calculateZoomedMax(zoomedMin, currentMin, currentMax, _zoomFactor);
+        _calculateZoomedMax(zoomedMin, currentMin, currentMax, _zoomFactor);
 
     setState(() {
       _thresholdProgressbarMaximum = zoomedMax;

--- a/lib/src/oscilloscope/alternative_simple_oscilloscope.dart
+++ b/lib/src/oscilloscope/alternative_simple_oscilloscope.dart
@@ -32,6 +32,13 @@ import 'package:syncfusion_flutter_charts/charts.dart';
 /// - Extra plot lines for additional reference markers
 /// - Tooltip support for data point inspection
 ///
+/// Data updates are pushed to the chart through
+/// [ChartSeriesController.updateDataSource] so that replacing a series with a
+/// shorter list correctly removes the stale trailing points, and high-frequency
+/// data-only refreshes avoid a full [SfCartesianChart] rebuild. Use
+/// [AlternativeSimpleOscilloscopeState.clearData] through a [GlobalKey] to
+/// immediately clear all rendered data.
+///
 /// Example usage:
 /// ```dart
 /// AlternativeSimpleOscilloscope(
@@ -75,24 +82,50 @@ class AlternativeSimpleOscilloscope extends StatefulWidget {
 
   @override
   State<AlternativeSimpleOscilloscope> createState() =>
-      _AlternativeSimpleOscilloscopeState();
+      AlternativeSimpleOscilloscopeState();
 }
 
-class _AlternativeSimpleOscilloscopeState
+/// State for [AlternativeSimpleOscilloscope].
+///
+/// Exposed publicly so consumers can drive imperative updates through a
+/// [GlobalKey]:
+///
+/// ```dart
+/// final key = GlobalKey<AlternativeSimpleOscilloscopeState>();
+/// AlternativeSimpleOscilloscope(key: key, ...);
+/// key.currentState?.clearData();
+/// ```
+///
+/// The state owns the mutable per-series data sources handed to the chart and
+/// keeps them in sync with [OscilloscopeAxisChartData.dataPoints] via
+/// [ChartSeriesController.updateDataSource]. This avoids a full
+/// [SfCartesianChart] rebuild on data-only changes and correctly truncates the
+/// stale trailing points when a series shrinks.
+class AlternativeSimpleOscilloscopeState
     extends State<AlternativeSimpleOscilloscope> {
   double _thresholdProgressbarValue = 0.0;
   double _thresholdValue = 0.0;
   double _sliderBottomPadding = 0.0;
 
-  final GlobalKey<_AlternativeSimpleOscilloscopeState> _primaryXAxisRenderKey =
-      GlobalKey<_AlternativeSimpleOscilloscopeState>();
-  final GlobalKey<_AlternativeSimpleOscilloscopeState> _primaryYAxisRenderKey =
-      GlobalKey<_AlternativeSimpleOscilloscopeState>();
+  final GlobalKey<AlternativeSimpleOscilloscopeState> _primaryXAxisRenderKey =
+      GlobalKey<AlternativeSimpleOscilloscopeState>();
+  final GlobalKey<AlternativeSimpleOscilloscopeState> _primaryYAxisRenderKey =
+      GlobalKey<AlternativeSimpleOscilloscopeState>();
 
   late double _thresholdProgressbarMaximum;
   late double _thresholdProgressbarMinimum;
   late double _zoomFactor = 1.0;
   late double _zoomPosition = 0.0;
+
+  /// Mutable data source lists owned by this state. These are the lists handed
+  /// to each [LineSeries] as its `dataSource`; they are updated in place so the
+  /// series keep a stable list identity while their contents change.
+  late List<List<OscilloscopePoint>> _dataSources;
+
+  /// Syncfusion series controllers, one per series, captured through
+  /// [LineSeries.onRendererCreated]. Used to push incremental data updates
+  /// without rebuilding the whole chart.
+  late List<ChartSeriesController?> _seriesControllers;
 
   Timer? _doubleTapTimer;
   int _pointerCount = 0;
@@ -104,6 +137,11 @@ class _AlternativeSimpleOscilloscopeState
   @override
   void initState() {
     super.initState();
+    _dataSources = widget.oscilloscopeAxisChartData.dataPoints
+        .map((list) => List<OscilloscopePoint>.from(list))
+        .toList();
+    _seriesControllers =
+        List<ChartSeriesController?>.generate(_dataSources.length, (_) => null);
     _thresholdProgressbarMaximum =
         widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision *
             widget.oscilloscopeAxisChartData.numberOfDivisions;
@@ -119,12 +157,18 @@ class _AlternativeSimpleOscilloscopeState
 
   @override
   void dispose() {
+    _dataSources.clear();
+    _seriesControllers.clear();
+    _doubleTapTimer?.cancel();
     super.dispose();
   }
 
   @override
   void didUpdateWidget(covariant AlternativeSimpleOscilloscope oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    _handleDataUpdate(oldWidget.oscilloscopeAxisChartData.dataPoints,
+        widget.oscilloscopeAxisChartData.dataPoints);
 
     if (widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision !=
             oldWidget.oscilloscopeAxisChartData.verticalAxisValuePerDivision ||
@@ -136,6 +180,107 @@ class _AlternativeSimpleOscilloscopeState
         _thresholdProgressbarValue = _thresholdValue;
         _handleZoom();
       });
+    }
+  }
+
+  /// Pushes incremental data updates to the chart through the series
+  /// controllers.
+  ///
+  /// When the number of series changes the chart is rebuilt via [setState]
+  /// (this is rare). Otherwise each series' owned data source is updated in
+  /// place and the change is described to Syncfusion with
+  /// [ChartSeriesController.updateDataSource]:
+  ///
+  /// * same length -> re-render the whole range,
+  /// * shrink      -> re-render the survivors then remove the trailing points
+  ///                  (this is what clears the stale trailing points),
+  /// * grow        -> re-render the existing points then append the new ones.
+  ///
+  /// No [setState] is needed for same-count updates, so high-frequency
+  /// data-only refreshes skip a full [SfCartesianChart] reconciliation.
+  void _handleDataUpdate(
+      List<List<OscilloscopePoint>> oldData,
+      List<List<OscilloscopePoint>> newData) {
+    if (newData.length != _dataSources.length) {
+      setState(() {
+        _dataSources =
+            newData.map((list) => List<OscilloscopePoint>.from(list)).toList();
+        _seriesControllers =
+            List<ChartSeriesController?>.generate(_dataSources.length, (_) => null);
+      });
+      return;
+    }
+
+    for (int i = 0; i < newData.length; i++) {
+      final controller = _seriesControllers[i];
+      final source = _dataSources[i];
+      final incoming = newData[i];
+
+      if (identical(source, incoming) && source.length == incoming.length) {
+        continue;
+      }
+
+      final oldLen = source.length;
+      source
+        ..clear()
+        ..addAll(incoming);
+      final newLen = source.length;
+
+      if (controller == null) {
+        continue;
+      }
+
+      if (newLen == oldLen) {
+        if (newLen > 0) {
+          controller.updateDataSource(
+            updatedDataIndexes: List<int>.generate(newLen, (i) => i),
+          );
+        }
+      } else if (newLen < oldLen) {
+        if (newLen > 0) {
+          controller.updateDataSource(
+            updatedDataIndexes: List<int>.generate(newLen, (i) => i),
+          );
+        }
+        controller.updateDataSource(
+          removedDataIndexes:
+              List<int>.generate(oldLen - newLen, (i) => newLen + i),
+        );
+      } else {
+        if (oldLen > 0) {
+          controller.updateDataSource(
+            updatedDataIndexes: List<int>.generate(oldLen, (i) => i),
+          );
+        }
+        controller.updateDataSource(
+          addedDataIndexes:
+              List<int>.generate(newLen - oldLen, (i) => oldLen + i),
+        );
+      }
+    }
+  }
+
+  /// Immediately clears every rendered series.
+  ///
+  /// This bypasses the widget rebuild cycle so the chart is emptied on the next
+  /// frame regardless of the consumer's refresh cadence. Subsequent updates
+  /// delivered through [didUpdateWidget] repopulate the chart normally.
+  ///
+  /// ```dart
+  /// final key = GlobalKey<AlternativeSimpleOscilloscopeState>();
+  /// AlternativeSimpleOscilloscope(key: key, ...);
+  /// key.currentState?.clearData();
+  /// ```
+  void clearData() {
+    for (int i = 0; i < _dataSources.length; i++) {
+      final controller = _seriesControllers[i];
+      final oldLen = _dataSources[i].length;
+      _dataSources[i].clear();
+      if (controller != null && oldLen > 0) {
+        controller.updateDataSource(
+          removedDataIndexes: List<int>.generate(oldLen, (i) => i),
+        );
+      }
     }
   }
 
@@ -292,16 +437,19 @@ class _AlternativeSimpleOscilloscopeState
                             .verticalAxisValuePerDivision,
                       ),
                       series: [
-                        ...widget.oscilloscopeAxisChartData.dataPoints
-                            .asMap()
-                            .entries
-                            .map((entry) {
+                        ..._dataSources.asMap().entries.map((entry) {
                           return LineSeries<OscilloscopePoint, double>(
+                            key: ValueKey<String>('series_${entry.key}'),
                             dataLabelSettings:
                                 const DataLabelSettings(isVisible: false),
                             enableTooltip:
                                 widget.oscilloscopeAxisChartData.enableTooltip,
-                            dataSource: entry.value,
+                            dataSource: _dataSources[entry.key],
+                            onRendererCreated: (ChartSeriesController controller) {
+                              if (entry.key < _seriesControllers.length) {
+                                _seriesControllers[entry.key] = controller;
+                              }
+                            },
                             xValueMapper: (OscilloscopePoint data, _) => data.x,
                             yValueMapper: (OscilloscopePoint data, _) => data.y,
                             animationDuration: 0,

--- a/lib/src/oscilloscope/oscilloscope_point.dart
+++ b/lib/src/oscilloscope/oscilloscope_point.dart
@@ -43,7 +43,7 @@ class OscilloscopePoint {
           y == other.y;
 
   @override
-  int get hashCode => x.hashCode ^ y.hashCode;
+  int get hashCode => Object.hash(x, y);
 
   @override
   String toString() => 'OscilloscopePoint($x, $y)';

--- a/lib/src/oscilloscope/simple_oscilloscope.dart
+++ b/lib/src/oscilloscope/simple_oscilloscope.dart
@@ -64,10 +64,8 @@ class _SimpleOscilloscopeState extends State<SimpleOscilloscope> {
   double _thresholdValue = 0.0;
   double _sliderBottomPadding = 0.0;
 
-  final GlobalKey<_SimpleOscilloscopeState> _chartAndLabelAreaRenderKey =
-      GlobalKey<_SimpleOscilloscopeState>();
-  final GlobalKey<_SimpleOscilloscopeState> _chartAreaRenderKey =
-      GlobalKey<_SimpleOscilloscopeState>();
+  final GlobalKey _chartAndLabelAreaRenderKey = GlobalKey();
+  final GlobalKey _chartAreaRenderKey = GlobalKey();
 
   @override
   void initState() {
@@ -88,16 +86,24 @@ class _SimpleOscilloscopeState extends State<SimpleOscilloscope> {
   void didUpdateWidget(covariant SimpleOscilloscope oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision !=
+    final bool axisConfigChanged =
+        widget.oscilloscopeAxisChartData.verticalAxisValuePerDivision !=
             oldWidget.oscilloscopeAxisChartData.verticalAxisValuePerDivision ||
         widget.oscilloscopeAxisChartData.numberOfDivisions !=
-            oldWidget.oscilloscopeAxisChartData.numberOfDivisions ||
-        _thresholdValue != widget.oscilloscopeAxisChartData.threshold) {
+            oldWidget.oscilloscopeAxisChartData.numberOfDivisions;
+    if (axisConfigChanged ||
+        widget.oscilloscopeAxisChartData.threshold !=
+            oldWidget.oscilloscopeAxisChartData.threshold) {
       setState(() {
         _thresholdValue = widget.oscilloscopeAxisChartData.threshold;
         _thresholdProgressbarValue = _thresholdValue;
         _clampThresholdProgressbarValue();
       });
+      if (axisConfigChanged) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _calculateBottomPadding();
+        });
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,12 +18,12 @@ platforms:
   windows:
 
 dependencies:
-  syncfusion_flutter_core: ^33.2.3
-  syncfusion_flutter_sliders: ^33.2.3
+  syncfusion_flutter_core: ^34.1.33
+  syncfusion_flutter_sliders: ^34.1.33
   fl_chart: ^1.2.0
   flutter:
     sdk: flutter
-  syncfusion_flutter_charts: ^33.2.3
+  syncfusion_flutter_charts: ^34.1.33
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: floscilloscope
 description: "An oscilloscope widget featuring dynamic chart rendering, threshold manipulation, zoom/pan, customizable axes, multi-data series, and interactive threshold sliders."
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/aazirani/floscilloscope
 repository: https://github.com/aazirani/floscilloscope
 

--- a/test/alternative_simple_oscilloscope_test.dart
+++ b/test/alternative_simple_oscilloscope_test.dart
@@ -170,5 +170,239 @@ void main() {
 
       expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
     });
+
+    testWidgets('exposes a public state reachable via GlobalKey', (WidgetTester tester) async {
+      final key = GlobalKey<AlternativeSimpleOscilloscopeState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AlternativeSimpleOscilloscope(
+              key: key,
+              oscilloscopeAxisChartData: testData,
+            ),
+          ),
+        ),
+      );
+
+      expect(key.currentState, isA<AlternativeSimpleOscilloscopeState>());
+    });
+
+    testWidgets('handles data shrink without throwing', (WidgetTester tester) async {
+      final harnessKey = GlobalKey<_DataHarnessState>();
+      final shorter = OscilloscopeAxisChartData(
+        dataPoints: [
+          [const OscilloscopePoint(0, 0)],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _DataHarness(key: harnessKey, data: testData),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      harnessKey.currentState!.replace(shorter);
+      await tester.pump();
+
+      expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
+    });
+
+    testWidgets('handles data grow without throwing', (WidgetTester tester) async {
+      final harnessKey = GlobalKey<_DataHarnessState>();
+      final longer = OscilloscopeAxisChartData(
+        dataPoints: [
+          [
+            const OscilloscopePoint(0, 0),
+            const OscilloscopePoint(1, 1),
+            const OscilloscopePoint(2, 2),
+            const OscilloscopePoint(3, 3),
+            const OscilloscopePoint(4, 4),
+          ],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _DataHarness(key: harnessKey, data: testData),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      harnessKey.currentState!.replace(longer);
+      await tester.pump();
+
+      expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
+    });
+
+    testWidgets('handles series count changes without throwing', (WidgetTester tester) async {
+      final harnessKey = GlobalKey<_DataHarnessState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _DataHarness(key: harnessKey, data: testData),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      harnessKey.currentState!.replace(OscilloscopeAxisChartData(
+        dataPoints: <List<OscilloscopePoint>>[],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      ));
+      await tester.pump();
+
+      harnessKey.currentState!.replace(OscilloscopeAxisChartData(
+        dataPoints: [
+          [const OscilloscopePoint(0, 0)],
+          [const OscilloscopePoint(0, 1)],
+          [const OscilloscopePoint(0, 2)],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      ));
+      await tester.pump();
+
+      harnessKey.currentState!.replace(testData);
+      await tester.pump();
+
+      expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
+    });
+
+    testWidgets('clearData() immediately empties the chart without throwing', (WidgetTester tester) async {
+      final chartKey = GlobalKey<AlternativeSimpleOscilloscopeState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AlternativeSimpleOscilloscope(
+              key: chartKey,
+              oscilloscopeAxisChartData: testData,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      chartKey.currentState!.clearData();
+      await tester.pump();
+
+      expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
+      expect(chartKey.currentState, isNotNull);
+    });
+
+    testWidgets('chart can be repopulated after clearData()', (WidgetTester tester) async {
+      final chartKey = GlobalKey<AlternativeSimpleOscilloscopeState>();
+      final harnessKey = GlobalKey<_DataWrapperState>();
+      final freshData = OscilloscopeAxisChartData(
+        dataPoints: [
+          [const OscilloscopePoint(5, 5), const OscilloscopePoint(6, 6)],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _DataWrapper(
+              key: harnessKey,
+              chartKey: chartKey,
+              data: testData,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      harnessKey.currentState!.clearAndReplace(freshData);
+      await tester.pump();
+
+      expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
+    });
   });
+}
+
+class _DataHarness extends StatefulWidget {
+  final OscilloscopeAxisChartData data;
+  const _DataHarness({super.key, required this.data});
+
+  @override
+  State<_DataHarness> createState() => _DataHarnessState();
+}
+
+class _DataHarnessState extends State<_DataHarness> {
+  late OscilloscopeAxisChartData _data;
+
+  @override
+  void initState() {
+    super.initState();
+    _data = widget.data;
+  }
+
+  void replace(OscilloscopeAxisChartData data) {
+    setState(() => _data = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlternativeSimpleOscilloscope(oscilloscopeAxisChartData: _data);
+  }
+}
+
+class _DataWrapper extends StatefulWidget {
+  final GlobalKey<AlternativeSimpleOscilloscopeState> chartKey;
+  final OscilloscopeAxisChartData data;
+  const _DataWrapper({
+    super.key,
+    required this.chartKey,
+    required this.data,
+  });
+
+  @override
+  State<_DataWrapper> createState() => _DataWrapperState();
+}
+
+class _DataWrapperState extends State<_DataWrapper> {
+  late OscilloscopeAxisChartData _data;
+
+  @override
+  void initState() {
+    super.initState();
+    _data = widget.data;
+  }
+
+  void clearAndReplace(OscilloscopeAxisChartData data) {
+    widget.chartKey.currentState?.clearData();
+    setState(() => _data = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlternativeSimpleOscilloscope(
+      key: widget.chartKey,
+      oscilloscopeAxisChartData: _data,
+    );
+  }
 }

--- a/test/alternative_simple_oscilloscope_test.dart
+++ b/test/alternative_simple_oscilloscope_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:floscilloscope/floscilloscope.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
 
 void main() {
   group('AlternativeSimpleOscilloscope Widget Tests', () {
@@ -341,12 +342,132 @@ void main() {
 
       expect(find.byType(AlternativeSimpleOscilloscope), findsOneWidget);
     });
+
+    testWidgets('recaptures series controllers after a count change',
+        (WidgetTester tester) async {
+      final chartKey = GlobalKey<AlternativeSimpleOscilloscopeState>();
+      final harnessKey = GlobalKey<_DataHarnessState>();
+
+      final threeSeries = OscilloscopeAxisChartData(
+        dataPoints: [
+          [const OscilloscopePoint(0, 0), const OscilloscopePoint(1, 1)],
+          [const OscilloscopePoint(0, 1), const OscilloscopePoint(1, 2)],
+          [const OscilloscopePoint(0, 2), const OscilloscopePoint(1, 3)],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      );
+      final oneSeries = OscilloscopeAxisChartData(
+        dataPoints: [
+          [
+            const OscilloscopePoint(0, 0),
+            const OscilloscopePoint(1, 1),
+            const OscilloscopePoint(2, 2)
+          ],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _DataHarness(
+                key: harnessKey, chartKey: chartKey, data: threeSeries),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(chartKey.currentState!.controllerCount, 3);
+
+      // Shrink 3 -> 1: surviving series must recapture its controller.
+      harnessKey.currentState!.replace(oneSeries);
+      await tester.pumpAndSettle();
+      expect(chartKey.currentState!.controllerCount, 1);
+
+      // A subsequent same-count data update must still reach the controller
+      // (this is exactly the stale-data regression).
+      harnessKey.currentState!.replace(OscilloscopeAxisChartData(
+        dataPoints: [
+          [
+            const OscilloscopePoint(0, 5),
+            const OscilloscopePoint(1, 6),
+            const OscilloscopePoint(2, 7)
+          ],
+        ],
+        horizontalAxisLabel: 'Time',
+        verticalAxisLabel: 'Voltage',
+        horizontalAxisUnit: 's',
+        verticalAxisUnit: 'V',
+      ));
+      await tester.pumpAndSettle();
+      expect(chartKey.currentState!.controllerCount, 1);
+
+      // Grow 1 -> 3.
+      harnessKey.currentState!.replace(threeSeries);
+      await tester.pumpAndSettle();
+      expect(chartKey.currentState!.controllerCount, 3);
+    });
+
+    testWidgets('threshold value is not reverted by a data-tick rebuild',
+        (WidgetTester tester) async {
+      final chartKey = GlobalKey<AlternativeSimpleOscilloscopeState>();
+      final harnessKey = GlobalKey<_DataHarnessState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _DataHarness(
+                key: harnessKey, chartKey: chartKey, data: testData),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(chartKey.currentState!.currentThresholdValue, 1.0);
+
+      // Simulate a user drag that set the local threshold.
+      chartKey.currentState!.currentThresholdValue = 3.5;
+
+      // Data-tick rebuild with the SAME threshold prop (consumer did not
+      // round-trip the dragged value back into the data model).
+      harnessKey.currentState!.replace(testData);
+      await tester.pumpAndSettle();
+
+      // Must NOT have reverted to the prop value.
+      expect(chartKey.currentState!.currentThresholdValue, 3.5);
+    });
+
+    testWidgets('wraps the chart in a RepaintBoundary',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AlternativeSimpleOscilloscope(
+              oscilloscopeAxisChartData: testData,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final chart = find.byType(SfCartesianChart);
+      expect(chart, findsOneWidget);
+      expect(
+        find.ancestor(of: chart, matching: find.byType(RepaintBoundary)),
+        findsWidgets,
+      );
+    });
   });
 }
 
 class _DataHarness extends StatefulWidget {
   final OscilloscopeAxisChartData data;
-  const _DataHarness({super.key, required this.data});
+  final GlobalKey<AlternativeSimpleOscilloscopeState>? chartKey;
+  const _DataHarness({super.key, required this.data, this.chartKey});
 
   @override
   State<_DataHarness> createState() => _DataHarnessState();
@@ -367,7 +488,10 @@ class _DataHarnessState extends State<_DataHarness> {
 
   @override
   Widget build(BuildContext context) {
-    return AlternativeSimpleOscilloscope(oscilloscopeAxisChartData: _data);
+    return AlternativeSimpleOscilloscope(
+      key: widget.chartKey,
+      oscilloscopeAxisChartData: _data,
+    );
   }
 }
 


### PR DESCRIPTION
# floscilloscope 1.1.2

A real-time-friendly release for `AlternativeSimpleOscilloscope`, plus dependency upgrades, documentation, and a streaming example.

## Highlights

- **Reliable high-frequency data updates.** `AlternativeSimpleOscilloscope` now owns its series data internally and syncs changes to the chart through `ChartSeriesController.updateDataSource`. Replacing a series with a shorter list no longer leaves stale trailing points, growing a series appends points correctly, and data-only refreshes skip a full `SfCartesianChart` rebuild — ideal for timer-driven waveforms.
- **Stable across series-count changes.** Adding or removing channels rebuilds each series with a fresh key so its controller is recaptured; updates never go silent after a channel change.
- **Instant clearing with `clearData()`.** The new public `AlternativeSimpleOscilloscopeState.clearData()` empties the chart immediately, bypassing the rebuild cycle:
  ```dart
  final key = GlobalKey<AlternativeSimpleOscilloscopeState>();
  AlternativeSimpleOscilloscope(key: key, oscilloscopeAxisChartData: data);
  key.currentState?.clearData();
  ```
- **Threshold that stays put while streaming.** In both `SimpleOscilloscope` and `AlternativeSimpleOscilloscope`, a threshold set by dragging the slider is no longer reverted on every data-tick rebuild.
- **Smoother rendering.** `AlternativeSimpleOscilloscope`'s chart is now wrapped in a `RepaintBoundary`, matching `SimpleOscilloscope`.

## Upgrades & cleanup

- Syncfusion dependencies bumped to `^34.1.33` (`syncfusion_flutter_charts`, `_core`, `_sliders`) in the package and the example.
- Streaming (timer-driven) example demonstrating two-channel real-time updates.
- `OscilloscopePoint.hashCode` now uses `Object.hash`.
- Internal: reusable index buffer, plain `GlobalKey` types, re-measured slider padding on axis-config changes.
- **Minor breaking:** the undocumented helpers `calculateZoomedMin`/`calculateZoomedMax` are now private (`_calculateZoomedMin`/`_calculateZoomedMax`).

## Verified

- `flutter analyze` — no issues (package + example).
- `flutter test` — all tests pass, including regressions for series-count changes, threshold retention during streaming, and the `RepaintBoundary` wrapper.